### PR TITLE
Add Docker Compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Exclude git and local environment files
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use lightweight Python image
+FROM python:3.11-slim
+
+# Prevent Python from writing pyc files and buffer stdout/stderr
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install build dependencies for packages like meshtastic
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Expose port used by Django's development server
+EXPOSE 8000
+
+# Default command runs migrations and starts server
+CMD ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - .:/app

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,19 @@ The project is organized into three main Django apps:
     The Meshtastic listener (`listen_device` command) is configured to start automatically in a separate thread when the Django development server starts. You should see log messages indicating its startup in the console.
     By default, the web application will be accessible at `http://127.0.0.1:8000/`.
 
+## Run with Docker Compose
+
+An easier way to start the project is via Docker Compose. This builds a container with all dependencies and runs the Django development server.
+
+1. Copy `.env.example` to `.env` and adjust values as needed.
+2. Build and start the service:
+
+    ```bash
+    docker-compose up --build
+    ```
+
+   The dashboard will be available at [http://localhost:8000](http://localhost:8000).
+
 ## Usage
 
 * **Dashboard:** Access the main dashboard at `http://127.0.0.1:8000/dashboard/` (or the root `/` if configured as such).


### PR DESCRIPTION
## Summary
- add Dockerfile for running the Django app in a container
- create docker-compose.yml for easy startup
- document Docker-based workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b4017d6b3c83318a83a959303e9dd3